### PR TITLE
Search users enpoint - V1

### DIFF
--- a/app/controllers/api/v1/search_skills_controller.rb
+++ b/app/controllers/api/v1/search_skills_controller.rb
@@ -1,0 +1,25 @@
+class Api::V1::SearchSkillsController < ApplicationController
+  before_action :searched_users, only: [:index]
+  before_action :check_for_empty_query
+
+  def index
+    if !@users.empty?
+      render json: SearchedUserSerializer.new(@users), status: 200
+    elsif searched_users.empty?
+      render json: {error: "No users found with that skill."}, status: 200
+    end 
+  end
+
+ private
+
+  def searched_users 
+    @users = User.search_for_skills(params[:query])
+  end
+
+  def check_for_empty_query
+    if params[:query].blank?
+      render json: {error: "Please enter a skill to search for."}, status: 400
+    end
+  end
+
+end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -21,6 +21,6 @@ class Api::V1::UsersController < ApplicationController
   private
 
   def user_params
-    params.permit(:first_name, :last_name, :email, :address, :lat, :lon, :is_remote)
+    params.permit(:first_name, :last_name, :email, :lat, :lon, :is_remote, :about, :city, :state, :zipcode, :street)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
-  validates :first_name, :last_name, :address, :lat, :lon, presence: true
+  validates :first_name, :last_name, :lat, :lon, presence: true
+  validates :street, :city, :state, :zipcode, presence: true
   validates :is_remote, inclusion: { in: [true, false] }
   validates :email, presence: true, uniqueness: true
   has_many :user_meetings

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,10 @@ class User < ApplicationRecord
   has_many :user_meetings
   has_many :meetings, through: :user_meetings
   has_many :skills
+
+  def self.search_for_skills(query)
+    User
+    .joins(:skills)
+    .where("skills.name ILIKE ?", "%#{query}%")
+  end
 end

--- a/app/serializers/searched_user_serializer.rb
+++ b/app/serializers/searched_user_serializer.rb
@@ -1,7 +1,7 @@
 class SearchedUserSerializer
 include JSONAPI::Serializer
 
-  attributes :first_name, :last_name, :skills
+  attributes :first_name, :last_name, :is_remote, :skills
 
   attribute :skills do |user|
     user.skills.map do |skill|

--- a/app/serializers/searched_user_serializer.rb
+++ b/app/serializers/searched_user_serializer.rb
@@ -3,6 +3,7 @@ include JSONAPI::Serializer
 
   attributes :first_name, :last_name, :is_remote, :skills
 
+  #could potentially have a parent class to inherit from to DRY up code
   attribute :skills do |user|
     user.skills.map do |skill|
       {

--- a/app/serializers/searched_user_serializer.rb
+++ b/app/serializers/searched_user_serializer.rb
@@ -1,0 +1,18 @@
+class SearchedUserSerializer
+include JSONAPI::Serializer
+
+  attributes :first_name, :last_name, :skills
+
+  attribute :skills do |user|
+    user.skills.map do |skill|
+      {
+        name: skill.name,
+        proficiency: skill.proficiency
+      }
+    end
+  end
+
+  #placeholder to render the proximity of the user to the searcher
+  #how are we going to get the lat/lon of the searcher? 
+  # attribute :proximity
+end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -24,4 +24,13 @@ include JSONAPI::Serializer
       }
     end
   end
+
+  attribute :address do |user|
+    {
+      street: user.street,
+      city: user.city,
+      state: user.state,
+      zipcode: user.zipcode
+    }
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :users, only: [:show, :create]
+      resources :search_skills, only: [:index]
     end
   end
 end

--- a/db/migrate/20231202192151_remove_address_from_users_and_add_city_state_zipcode_street.rb
+++ b/db/migrate/20231202192151_remove_address_from_users_and_add_city_state_zipcode_street.rb
@@ -1,0 +1,9 @@
+class RemoveAddressFromUsersAndAddCityStateZipcodeStreet < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :users, :address, :string
+    add_column :users, :city, :string
+    add_column :users, :state, :string
+    add_column :users, :zipcode, :string
+    add_column :users, :street, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_01_223804) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_02_192151) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -47,13 +47,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_01_223804) do
     t.string "first_name"
     t.string "last_name"
     t.string "email"
-    t.string "address"
     t.float "lat"
     t.float "lon"
     t.boolean "is_remote"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "about"
+    t.string "city"
+    t.string "state"
+    t.string "zipcode"
+    t.string "street"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,12 +6,18 @@
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
 User.destroy_all
+Skill.destroy_all
 
 user1 = User.create(first_name: "Steve", last_name: "Jobs", email: "steve@gmail.com", address: "12345 street st.", lat: "1.12", lon: "1.12", is_remote: "true", about: "I am a very good programmer")
 user2 = User.create(first_name: "Ethan", last_name: "Bustamante", email: "Ethan@gmail.com", address: "Ethan street st.", lat: "1.12", lon: "1.12", is_remote: "true", about: "I am a also very good programmer")
+user3 = User.create(first_name: "Tyler", last_name: "Blackmon", email: "tyler#gmail.com", address: "Tyler street st.", lat: "1.12", lon: "1.12", is_remote: "true", about: "I enjoy long walks on the beach")
 
 steveskill1 = Skill.create(name: "Apple", proficiency: 5, user_id: user1.id)
 steveskill2 = Skill.create(name: "Swift", proficiency: 5, user_id: user1.id)
+steveskill3 = Skill.create(name: "knitting", proficiency: 3, user_id: user1.id)
 
 ethanskill1 = Skill.create(name: "Ruby", proficiency: 5, user_id: user2.id)
 ethanskill2 = Skill.create(name: "Rails", proficiency: 5, user_id: user2.id)
+ethanskill3 = Skill.create(name: "knitting", proficiency: 1, user_id: user2.id) 
+
+tylerskill1 = Skill.create(name: "Ruby", proficiency: 5, user_id: user3.id)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,9 +8,9 @@
 User.destroy_all
 Skill.destroy_all
 
-user1 = User.create(first_name: "Steve", last_name: "Jobs", email: "steve@gmail.com", address: "12345 street st.", lat: "1.12", lon: "1.12", is_remote: "true", about: "I am a very good programmer")
-user2 = User.create(first_name: "Ethan", last_name: "Bustamante", email: "Ethan@gmail.com", address: "Ethan street st.", lat: "1.12", lon: "1.12", is_remote: "true", about: "I am a also very good programmer")
-user3 = User.create(first_name: "Tyler", last_name: "Blackmon", email: "tyler#gmail.com", address: "Tyler street st.", lat: "1.12", lon: "1.12", is_remote: "true", about: "I enjoy long walks on the beach")
+user1 = User.create(first_name: "Steve", last_name: "Jobs", email: "steve@gmail.com", street: "1234 Street", city: "Cupertino", state: "CA", zipcode: "12345", lat: "1.12", lon: "1.12", is_remote: "true", about: "I am a very good programmer")
+user2 = User.create(first_name: "Ethan", last_name: "Bustamante", email: "Ethan@gmail.com", street: "1234 Street", city: "Denver", state: "CO", zipcode: "12345", lat: "1.12", lon: "1.12", is_remote: "true", about: "I am a also very good programmer")
+user3 = User.create(first_name: "Tyler", last_name: "Blackmon", email: "tyler#gmail.com", street: "1234 Street", city: "CO springs", state: "CO", zipcode: "12345", lat: "1.12", lon: "1.12", is_remote: "true", about: "I enjoy long walks on the beach")
 
 steveskill1 = Skill.create(name: "Apple", proficiency: 5, user_id: user1.id)
 steveskill2 = Skill.create(name: "Swift", proficiency: 5, user_id: user1.id)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,13 @@
 #
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
+User.destroy_all
+
+user1 = User.create(first_name: "Steve", last_name: "Jobs", email: "steve@gmail.com", address: "12345 street st.", lat: "1.12", lon: "1.12", is_remote: "true", about: "I am a very good programmer")
+user2 = User.create(first_name: "Ethan", last_name: "Bustamante", email: "Ethan@gmail.com", address: "Ethan street st.", lat: "1.12", lon: "1.12", is_remote: "true", about: "I am a also very good programmer")
+
+steveskill1 = Skill.create(name: "Apple", proficiency: 5, user_id: user1.id)
+steveskill2 = Skill.create(name: "Swift", proficiency: 5, user_id: user1.id)
+
+ethanskill1 = Skill.create(name: "Ruby", proficiency: 5, user_id: user2.id)
+ethanskill2 = Skill.create(name: "Rails", proficiency: 5, user_id: user2.id)

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,7 +3,10 @@ FactoryBot.define do
     first_name { Faker::Name.first_name }
     last_name { Faker::Name.last_name }
     email { Faker::Internet.email }
-    address { Faker::Address.full_address }
+    street { Faker::Address.street_address }
+    city { Faker::Address.city }
+    state { Faker::Address.state }
+    zipcode {Faker::Address.zip_code}
     lat { Faker::Address.latitude }
     lon { Faker::Address.longitude }
     is_remote { Faker::Boolean.boolean }

--- a/spec/requests/api/v1/create_user_spec.rb
+++ b/spec/requests/api/v1/create_user_spec.rb
@@ -8,8 +8,11 @@ RSpec.describe "create user endpoint", type: :request do
         user_info = {
           "first_name": "Antoine",
           "last_name": "Aube",
-          "email": "yetanother@gmail.com",
-          "address": "12345 street st.",
+          "email": "taken@gmail.com",
+          "street": "12345 street st.",
+          "city": "Salt Lake City",
+          "state": "UT",
+          "zipcode": "12345",
           "lat": "1.12",
           "lon": "1.12",
           "is_remote": "true"
@@ -38,8 +41,7 @@ RSpec.describe "create user endpoint", type: :request do
       expect(attributes[:last_name]).to eq(user.last_name)
       expect(attributes).to have_key(:email)
       expect(attributes[:email]).to eq(user.email)
-      expect(attributes).to have_key(:address)  
-      expect(attributes[:address]).to eq(user.address)  
+      expect(attributes).to have_key(:address)    
       expect(attributes).to have_key(:lat)
       expect(attributes[:lat]).to eq(user.lat)
       expect(attributes).to have_key(:lon)
@@ -57,13 +59,16 @@ RSpec.describe "create user endpoint", type: :request do
       expect(User.count).to eq(1)
 
       user_info = {
-          "first_name": "Antoine",
-          "last_name": "Aube",
-          "email": "taken@gmail.com",
-          "address": "12345 street st.",
-          "lat": "1.12",
-          "lon": "1.12",
-          "is_remote": "true"
+        "first_name": "Antoine",
+        "last_name": "Aube",
+        "email": "taken@gmail.com",
+        "street": "12345 street st.",
+        "city": "Salt Lake City",
+        "state": "UT",
+        "zipcode": "12345",
+        "lat": "1.12",
+        "lon": "1.12",
+        "is_remote": "true"
       }
 
       post "/api/v1/users", params: user_info
@@ -84,7 +89,10 @@ RSpec.describe "create user endpoint", type: :request do
           "first_name": "",
           "last_name": "Aube",
           "email": "taken@gmail.com",
-          "address": "12345 street st.",
+          "street": "12345 street st.",
+          "city": "Salt Lake City",
+          "state": "UT",
+          "zipcode": "12345",
           "lat": "1.12",
           "lon": "1.12",
           "is_remote": "true"

--- a/spec/requests/api/v1/create_user_spec.rb
+++ b/spec/requests/api/v1/create_user_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "creae user endpoint" do
+RSpec.describe "create user endpoint", type: :request do
   describe "when I send a post request to '/api/v1/users' with a body" do 
     it "creates a user and send back all the user's data" do 
       expect(User.count).to eq(0)

--- a/spec/requests/api/v1/search_skills_spec.rb
+++ b/spec/requests/api/v1/search_skills_spec.rb
@@ -1,22 +1,23 @@
 require 'rails_helper'
 
 RSpec.describe "Search skills endpoint", type: :request do 
+  before :each do
+    @user1 = User.create(first_name: "Steve", last_name: "Jobs", email: "steve@gmail.com", street: "1234 Street", city: "Cupertino", state: "CA", zipcode: "12345", lat: "1.12", lon: "1.12", is_remote: "true", about: "I am a very good programmer")
+    @user2 = User.create(first_name: "Ethan", last_name: "Bustamante", email: "Ethan@gmail.com", street: "1234 Street", city: "Denver", state: "CO", zipcode: "12345", lat: "1.12", lon: "1.12", is_remote: "true", about: "I am a also very good programmer")
+    @user3 = User.create(first_name: "Tyler", last_name: "Blackmon", email: "tyler#gmail.com", street: "1234 Street", city: "CO springs", state: "CO", zipcode: "12345", lat: "1.12", lon: "1.12", is_remote: "true", about: "I enjoy long walks on the beach")
+    
+    @steveskill1 = Skill.create(name: "Apple", proficiency: 5, user_id: @user1.id)
+    @steveskill2 = Skill.create(name: "Swift", proficiency: 5, user_id: @user1.id)
+    @steveskill3 = Skill.create(name: "knitting", proficiency: 3, user_id: @user1.id)
+
+    @ethanskill1 = Skill.create(name: "Ruby", proficiency: 5, user_id: @user2.id)
+    @ethanskill2 = Skill.create(name: "Rails", proficiency: 5, user_id: @user2.id)
+    @ethanskill3 = Skill.create(name: "knitting", proficiency: 1, user_id: @user2.id) 
+
+    @tylerskill1 = Skill.create(name: "Ruby", proficiency: 5, user_id: @user3.id)
+  end
+
   describe "when I sent a query to '/api/v1/search_skills' " do 
-    before :each do
-      @user1 = User.create(first_name: "Steve", last_name: "Jobs", email: "steve@gmail.com", address: "12345 street st.", lat: "1.12", lon: "1.12", is_remote: "true", about: "I am a very good programmer")
-      @user2 = User.create(first_name: "Ethan", last_name: "Bustamante", email: "Ethan@gmail.com", address: "Ethan street st.", lat: "1.12", lon: "1.12", is_remote: "true", about: "I am a also very good programmer")
-      @user3 = User.create(first_name: "Tyler", last_name: "Blackmon", email: "tyler#gmail.com", address: "Tyler street st.", lat: "1.12", lon: "1.12", is_remote: "true", about: "I enjoy long walks on the beach")
-
-      @steveskill1 = Skill.create(name: "Apple", proficiency: 5, user_id: @user1.id)
-      @steveskill2 = Skill.create(name: "Swift", proficiency: 5, user_id: @user1.id)
-      @steveskill3 = Skill.create(name: "knitting", proficiency: 3, user_id: @user1.id)
-
-      @ethanskill1 = Skill.create(name: "Ruby", proficiency: 5, user_id: @user2.id)
-      @ethanskill2 = Skill.create(name: "Rails", proficiency: 5, user_id: @user2.id)
-      @ethanskill3 = Skill.create(name: "knitting", proficiency: 1, user_id: @user2.id) 
-
-      @tylerskill1 = Skill.create(name: "Ruby", proficiency: 5, user_id: @user3.id)
-    end
     it "returns all the users with their skills" do
       get "/api/v1/search_skills", params: {query: "knitting"}
 
@@ -36,6 +37,28 @@ RSpec.describe "Search skills endpoint", type: :request do
 
       user1_skills = steve[:attributes][:skills]
       expect(user1_skills.count).to eq(3)
+    end
+  end
+
+  describe "sad paths" do 
+    it "returns a message if no users are found" do
+      get "/api/v1/search_skills", params: {query: "rocket science"}
+
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+
+      response_body = JSON.parse(response.body, symbolize_names: true)
+      expect(response_body[:error]).to eq("No users found with that skill.")
+    end
+
+    it "returns a message if no users are found" do
+        get "/api/v1/search_skills", params: {query: ""}
+  
+        expect(response).to_not be_successful
+        expect(response.status).to eq(400)
+  
+        response_body = JSON.parse(response.body, symbolize_names: true)
+        expect(response_body[:error]).to eq("Please enter a skill to search for.")
     end
   end
 end

--- a/spec/requests/api/v1/search_skills_spec.rb
+++ b/spec/requests/api/v1/search_skills_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.descripe "Search skills endpoint", type: :request do 
+  describe "when I sent a query to '/api/v1/search_skills' " do 
+    it "returns all the users with their skills" do
+      get "/api/v1/search_skills", params: {skill: "knitting"}
+
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+    end
+  end
+end

--- a/spec/requests/api/v1/search_skills_spec.rb
+++ b/spec/requests/api/v1/search_skills_spec.rb
@@ -1,12 +1,41 @@
 require 'rails_helper'
 
-RSpec.descripe "Search skills endpoint", type: :request do 
+RSpec.describe "Search skills endpoint", type: :request do 
   describe "when I sent a query to '/api/v1/search_skills' " do 
+    before :each do
+      @user1 = User.create(first_name: "Steve", last_name: "Jobs", email: "steve@gmail.com", address: "12345 street st.", lat: "1.12", lon: "1.12", is_remote: "true", about: "I am a very good programmer")
+      @user2 = User.create(first_name: "Ethan", last_name: "Bustamante", email: "Ethan@gmail.com", address: "Ethan street st.", lat: "1.12", lon: "1.12", is_remote: "true", about: "I am a also very good programmer")
+      @user3 = User.create(first_name: "Tyler", last_name: "Blackmon", email: "tyler#gmail.com", address: "Tyler street st.", lat: "1.12", lon: "1.12", is_remote: "true", about: "I enjoy long walks on the beach")
+
+      @steveskill1 = Skill.create(name: "Apple", proficiency: 5, user_id: @user1.id)
+      @steveskill2 = Skill.create(name: "Swift", proficiency: 5, user_id: @user1.id)
+      @steveskill3 = Skill.create(name: "knitting", proficiency: 3, user_id: @user1.id)
+
+      @ethanskill1 = Skill.create(name: "Ruby", proficiency: 5, user_id: @user2.id)
+      @ethanskill2 = Skill.create(name: "Rails", proficiency: 5, user_id: @user2.id)
+      @ethanskill3 = Skill.create(name: "knitting", proficiency: 1, user_id: @user2.id) 
+
+      @tylerskill1 = Skill.create(name: "Ruby", proficiency: 5, user_id: @user3.id)
+    end
     it "returns all the users with their skills" do
-      get "/api/v1/search_skills", params: {skill: "knitting"}
+      get "/api/v1/search_skills", params: {query: "knitting"}
 
       expect(response).to be_successful
       expect(response.status).to eq(200)
+
+      response_body = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response_body[:data].count).to eq(2)
+
+      users = response_body[:data]
+      steve = users[0]
+
+      expect(steve[:attributes][:first_name]).to eq("Steve")
+      expect(steve[:attributes][:last_name]).to eq("Jobs")
+      expect(steve[:attributes][:is_remote]).to eq(true)
+
+      user1_skills = steve[:attributes][:skills]
+      expect(user1_skills.count).to eq(3)
     end
   end
 end

--- a/spec/requests/api/v1/user_request_spec.rb
+++ b/spec/requests/api/v1/user_request_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe 'Users API', type: :request do
   describe 'GET /api/v1/users/:user_id' do
     it 'returns user information' do
       user = create(:user)
+      require 'pry';binding.pry
       user_2 = create(:user)
       meeting = create(:meeting, users: [user, user_2])
       get "/api/v1/users/#{user.id}"

--- a/spec/requests/api/v1/user_request_spec.rb
+++ b/spec/requests/api/v1/user_request_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe 'Users API', type: :request do
   describe 'GET /api/v1/users/:user_id' do
     it 'returns user information' do
       user = create(:user)
-      require 'pry';binding.pry
       user_2 = create(:user)
       meeting = create(:meeting, users: [user, user_2])
       get "/api/v1/users/#{user.id}"


### PR DESCRIPTION
## Description

Please include a description of what was changed
This add the search for users by skill endpoint. I made a new search controller named specifically search_skills_controller, which could be more broad but I like the specificity and it made adding the route a bit easier within the nested namesspaces we already have. I added perhaps too much error handling here but this accounts for either the query being blank, or the query returning no users with that skill. 

I have a small note in the search user serializer as reminder to include the "proximity" attribute we will need. 

This PR also refactors the users table in the DB to have address separated out by city, street, state and zipcode. I also refactor any controllers, factories, and tests that needed adjusting due to this change.  I was able to create a nested object in the users serializer to return a single object for address per the FE's request. 

good times!

## Type of change

- [ ] fix
- [x] feat
- [x] test
- [x] refactor
- [ ] docs

## Checklist

- [x] code has been self reviewed
- [x] code runs without any errors
- [x] thorough testing has been implemented if adding feature
- [x] all tests pass

### Thanks!