### PR TITLE
refactor: search to use partial keywords

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,8 +10,13 @@ class User < ApplicationRecord
   before_validation :get_coords
 
   def self.search_for_skills(query)
-    skills = query.split(',').map { |skill| skill.strip.downcase}
-    User.joins(:skills).where("LOWER(skills.name) IN (?)", skills).distinct
+    skills = query.split(',').map { |skill| skill.strip.downcase }
+    
+    conditions = skills.map { |skill|
+      "LOWER(skills.name) ILIKE '%#{sanitize_sql_like(skill)}%'"
+    }.join(' OR ')
+  
+    User.joins(:skills).where(conditions).distinct
   end
 
   def self.remote_users


### PR DESCRIPTION
## Description

Please include a description of what was changed

This changes the search query to use partial keywords. I went back to using ILIKE rather than IN for the query, as well as OR to make it so all users were rendered based on the single keyword search, or multiple keywords (that can be partial). 

## Type of change

- [ ] fix
- [ ] feat
- [ ] test
- [x] refactor
- [ ] docs

## Checklist

- [ ] code has been self reviewed
- [x] code runs without any errors
- [ ] thorough testing has been implemented if adding feature
- [ ] all tests pass

### Thanks!