### PR TITLE
migration to update start and end times to be time fields rather than…

### DIFF
--- a/db/migrate/20231207004825_update_meetings_to_have_times.rb
+++ b/db/migrate/20231207004825_update_meetings_to_have_times.rb
@@ -1,0 +1,8 @@
+class UpdateMeetingsToHaveTimes < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :meetings, :start_time
+    remove_column :meetings, :end_time
+    add_column :meetings, :start_time, :time
+    add_column :meetings, :end_time, :time
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,18 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_02_192151) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_07_004825) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "meetings", force: :cascade do |t|
     t.date "date"
-    t.datetime "start_time"
-    t.datetime "end_time"
     t.boolean "is_accepted"
     t.string "purpose"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.time "start_time"
+    t.time "end_time"
   end
 
   create_table "skills", force: :cascade do |t|


### PR DESCRIPTION
… datetime fields

## Description

Changes the start_time and end_time columns on Meetings to actually be time columns, rather than datetime.

## Type of change

- [x] fix
- [ ] feat
- [ ] test
- [ ] refactor
- [ ] docs

## Checklist

- [x] code has been self reviewed
- [x] code runs without any errors
- [ ] thorough testing has been implemented if adding feature
- [x] all tests pass

### Thanks!